### PR TITLE
Get packaging ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,1 @@
+LICENSE.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pylint==1.2.1
 requests==2.3.0
 smmap==0.8.2
 wsgiref==0.1.2
+pypandoc==0.9.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(name='lolologist',
       classifiers=[
           'Development Status :: 4 - Beta',
           'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
-          'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,42 @@
+""" Set it up. """
+
+from __future__ import print_function
+
 from setuptools import setup
 import sys
 
+try:
+    import pypandoc
+    LONG_DESCRIPTION = pypandoc.convert('README.md', 'rst')
+    print("Converted README.md to rst")
+except (IOError, ImportError):
+    print("Could not convert README.md to rst. Falling back to Markdown", file=sys.stderr)
+    LONG_DESCRIPTION = open('README.md').read()
+
 REQUIREMENTS = [
-        'argparse',
-        'GitPython>=0.3.2.RC1',
-        'Pillow>=2.3.0',
-        'requests',
-        ]
+    'argparse',
+    'GitPython>=0.3.2.RC1',
+    'Pillow>=2.3.0',
+    'requests',
+    ]
 
 if sys.version_info <= (3,):
     REQUIREMENTS.append('configparser==3.5.0b2') # Using the beta for PyPy compatibility
 
 setup(name='lolologist',
-      version='0.4.0',
-      description='A utility that generates an image macro from your webcam whenever \
-              you commit to a git repository.',
+      version='0.5.0',
+      description=('A utility that automatically generates an image macro from your webcam whenever '
+                   'you commit to a git repository.'),
+      long_description=LONG_DESCRIPTION,
       classifiers=[
-          'Development Status :: 3 - Alpha',
+          'Development Status :: 4 - Beta',
           'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
           'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: Implementation :: CPython',
+          'Programming Language :: Python :: Implementation :: PyPy',
           'Environment :: Console',
           'Operating System :: POSIX :: Linux',
           'Operating System :: MacOS :: MacOS X',
@@ -26,7 +44,9 @@ setup(name='lolologist',
           'Topic :: Utilities',
           'Topic :: Software Development :: Version Control',
       ],
+      keywords=['git', 'camera', 'webcam', 'commit', 'macro', 'image', 'lol', 'lulz', 'version', 'control'],
       url='https://github.com/arusahni/lolologist',
+      download_url='https://github.com/arusahni/lolologist/archive/v0.5.0',
       author='Aru Sahni',
       author_email='arusahni@gmail.com',
       license='MPL 2.0',
@@ -34,7 +54,7 @@ setup(name='lolologist',
       package_data={'lolologist':['LeagueGothic-Regular.otf', 'tranzlator.json']},
       include_package_data=True,
       install_requires=REQUIREMENTS,
-      entry_points = {
+      entry_points={
           'console_scripts': ['lolologist=lolologist.lolologist:main'],
       },
       zip_safe=False)


### PR DESCRIPTION
PyPi changes.

* Leaving alpha!
* Increment version to 0.5
* Formally dropped Python 2.6 support.
* Declaring Python 3 and PyPi compatibility.